### PR TITLE
Add Sum256 and Sum224 no-allocation functions

### DIFF
--- a/blake256_test.go
+++ b/blake256_test.go
@@ -159,30 +159,53 @@ func TestTwoWrites(t *testing.T) {
 	}
 }
 
-var bench = New()
-var buf = make([]byte, 8<<10)
+var buf_in = make([]byte, 8<<10)
+var buf_out = make([]byte, 32)
 
-func BenchmarkHash1K(b *testing.B) {
+func Benchmark1K(b *testing.B) {
 	b.SetBytes(1024)
 	for i := 0; i < b.N; i++ {
-		bench.Write(buf[:1024])
+		var bench = New()
+		bench.Write(buf_in[:1024])
+		bench.Sum(buf_out[0:0])
 	}
 }
 
-func BenchmarkHash8K(b *testing.B) {
-	b.SetBytes(int64(len(buf)))
+func Benchmark8K(b *testing.B) {
+	b.SetBytes(int64(len(buf_in)))
 	for i := 0; i < b.N; i++ {
-		bench.Write(buf)
+		var bench = New()
+		bench.Write(buf_in)
+		bench.Sum(buf_out[0:0])
 	}
 }
 
-func BenchmarkFull64(b *testing.B) {
+func Benchmark64(b *testing.B) {
 	b.SetBytes(64)
-	tmp := make([]byte, 32)
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		bench.Reset()
-		bench.Write(buf[:64])
-		bench.Sum(tmp[0:0])
+		var bench = New()
+		bench.Write(buf_in[:64])
+		bench.Sum(buf_out[0:0])
+	}
+}
+
+func Benchmark1KNoAlloc(b *testing.B) {
+	b.SetBytes(1024)
+	for i := 0; i < b.N; i++ {
+		Sum256(buf_in[:1024])
+	}
+}
+
+func Benchmark8KNoAlloc(b *testing.B) {
+	b.SetBytes(int64(len(buf_in)))
+	for i := 0; i < b.N; i++ {
+		Sum256(buf_in)
+	}
+}
+
+func Benchmark64NoAlloc(b *testing.B) {
+	b.SetBytes(64)
+	for i := 0; i < b.N; i++ {
+		Sum256(buf_in[:64])
 	}
 }

--- a/blake256_test.go
+++ b/blake256_test.go
@@ -95,7 +95,7 @@ var vectors224 = []blakeVector{
 		"Buffalo buffalo Buffalo buffalo buffalo buffalo Buffalo buffalo"},
 }
 
-func testVectors(t *testing.T, hashfunc func() hash.Hash, vectors []blakeVector) {
+func newTestVectors(t *testing.T, hashfunc func() hash.Hash, vectors []blakeVector) {
 	for i, v := range vectors {
 		h := hashfunc()
 		h.Write([]byte(v.in))
@@ -106,12 +106,30 @@ func testVectors(t *testing.T, hashfunc func() hash.Hash, vectors []blakeVector)
 	}
 }
 
-func Test256(t *testing.T) {
-	testVectors(t, blake256.New, vectors256)
+func TestNew256(t *testing.T) {
+	newTestVectors(t, blake256.New, vectors256)
 }
 
-func Test224(t *testing.T) {
-	testVectors(t, blake256.New224, vectors224)
+func TestNew224(t *testing.T) {
+	newTestVectors(t, blake256.New224, vectors224)
+}
+
+func TestSum256(t *testing.T) {
+	for i, v := range vectors256 {
+		res := fmt.Sprintf("%x", blake256.Sum256([]byte(v.in)))
+		if res != v.out {
+			t.Errorf("%d: expected %q, got %q", i, v.out, res)
+		}
+	}
+}
+
+func TestSum224(t *testing.T) {
+	for i, v := range vectors224 {
+		res := fmt.Sprintf("%x", blake256.Sum224([]byte(v.in)))
+		if res != v.out {
+			t.Errorf("%d: expected %q, got %q", i, v.out, res)
+		}
+	}
 }
 
 var vectors256salt = []struct{ out, in, salt string }{
@@ -169,7 +187,7 @@ func Benchmark1K(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var bench = blake256.New()
 		bench.Write(buf_in[:1024])
-		bench.Sum(buf_out[0:0])
+		_ = bench.Sum(buf_out[0:0])
 	}
 }
 
@@ -178,7 +196,7 @@ func Benchmark8K(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var bench = blake256.New()
 		bench.Write(buf_in)
-		bench.Sum(buf_out[0:0])
+		_ = bench.Sum(buf_out[0:0])
 	}
 }
 
@@ -187,27 +205,27 @@ func Benchmark64(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var bench = blake256.New()
 		bench.Write(buf_in[:64])
-		bench.Sum(buf_out[0:0])
+		_ = bench.Sum(buf_out[0:0])
 	}
 }
 
 func Benchmark1KNoAlloc(b *testing.B) {
 	b.SetBytes(1024)
 	for i := 0; i < b.N; i++ {
-		blake256.Sum256(buf_in[:1024])
+		_ = blake256.Sum256(buf_in[:1024])
 	}
 }
 
 func Benchmark8KNoAlloc(b *testing.B) {
 	b.SetBytes(int64(len(buf_in)))
 	for i := 0; i < b.N; i++ {
-		blake256.Sum256(buf_in)
+		_ = blake256.Sum256(buf_in)
 	}
 }
 
 func Benchmark64NoAlloc(b *testing.B) {
 	b.SetBytes(64)
 	for i := 0; i < b.N; i++ {
-		blake256.Sum256(buf_in[:64])
+		_ = blake256.Sum256(buf_in[:64])
 	}
 }

--- a/blake256_test.go
+++ b/blake256_test.go
@@ -5,13 +5,15 @@
 // worldwide. This software is distributed without any warranty.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-package blake256
+package blake256_test
 
 import (
 	"bytes"
 	"fmt"
 	"hash"
 	"testing"
+
+	"github.com/teknico/blake256"
 )
 
 func Test256C(t *testing.T) {
@@ -32,7 +34,7 @@ func Test256C(t *testing.T) {
 	}
 	data := make([]byte, 72)
 
-	h := New()
+	h := blake256.New()
 	h.Write(data[:1])
 	sum := h.Sum(nil)
 	if !bytes.Equal(hashes[0], sum) {
@@ -105,11 +107,11 @@ func testVectors(t *testing.T, hashfunc func() hash.Hash, vectors []blakeVector)
 }
 
 func Test256(t *testing.T) {
-	testVectors(t, New, vectors256)
+	testVectors(t, blake256.New, vectors256)
 }
 
 func Test224(t *testing.T) {
-	testVectors(t, New224, vectors224)
+	testVectors(t, blake256.New224, vectors224)
 }
 
 var vectors256salt = []struct{ out, in, salt string }{
@@ -123,7 +125,7 @@ var vectors256salt = []struct{ out, in, salt string }{
 
 func TestSalt(t *testing.T) {
 	for i, v := range vectors256salt {
-		h := NewSalt([]byte(v.salt))
+		h := blake256.NewSalt([]byte(v.salt))
 		h.Write([]byte(v.in))
 		res := fmt.Sprintf("%x", h.Sum(nil))
 		if res != v.out {
@@ -137,7 +139,7 @@ func TestSalt(t *testing.T) {
 			t.Errorf("expected panic for bad salt length")
 		}
 	}()
-	NewSalt([]byte{1, 2, 3, 4, 5, 6, 7, 8})
+	blake256.NewSalt([]byte{1, 2, 3, 4, 5, 6, 7, 8})
 }
 
 func TestTwoWrites(t *testing.T) {
@@ -145,12 +147,12 @@ func TestTwoWrites(t *testing.T) {
 	for i := range b {
 		b[i] = byte(i)
 	}
-	h1 := New()
+	h1 := blake256.New()
 	h1.Write(b[:1])
 	h1.Write(b[1:])
 	sum1 := h1.Sum(nil)
 
-	h2 := New()
+	h2 := blake256.New()
 	h2.Write(b)
 	sum2 := h2.Sum(nil)
 
@@ -165,7 +167,7 @@ var buf_out = make([]byte, 32)
 func Benchmark1K(b *testing.B) {
 	b.SetBytes(1024)
 	for i := 0; i < b.N; i++ {
-		var bench = New()
+		var bench = blake256.New()
 		bench.Write(buf_in[:1024])
 		bench.Sum(buf_out[0:0])
 	}
@@ -174,7 +176,7 @@ func Benchmark1K(b *testing.B) {
 func Benchmark8K(b *testing.B) {
 	b.SetBytes(int64(len(buf_in)))
 	for i := 0; i < b.N; i++ {
-		var bench = New()
+		var bench = blake256.New()
 		bench.Write(buf_in)
 		bench.Sum(buf_out[0:0])
 	}
@@ -183,7 +185,7 @@ func Benchmark8K(b *testing.B) {
 func Benchmark64(b *testing.B) {
 	b.SetBytes(64)
 	for i := 0; i < b.N; i++ {
-		var bench = New()
+		var bench = blake256.New()
 		bench.Write(buf_in[:64])
 		bench.Sum(buf_out[0:0])
 	}
@@ -192,20 +194,20 @@ func Benchmark64(b *testing.B) {
 func Benchmark1KNoAlloc(b *testing.B) {
 	b.SetBytes(1024)
 	for i := 0; i < b.N; i++ {
-		Sum256(buf_in[:1024])
+		blake256.Sum256(buf_in[:1024])
 	}
 }
 
 func Benchmark8KNoAlloc(b *testing.B) {
 	b.SetBytes(int64(len(buf_in)))
 	for i := 0; i < b.N; i++ {
-		Sum256(buf_in)
+		blake256.Sum256(buf_in)
 	}
 }
 
 func Benchmark64NoAlloc(b *testing.B) {
 	b.SetBytes(64)
 	for i := 0; i < b.N; i++ {
-		Sum256(buf_in[:64])
+		blake256.Sum256(buf_in[:64])
 	}
 }


### PR DESCRIPTION
The `New` and `Sum` methods, part of the `Hash` stdlib interface, allocate memory on the heap. The stdlib `sha256` package [uses](https://golang.org/src/crypto/sha256/sha256.go#273) a different method, `Sum256`, that does not allocate memory.

This change adds two functions, `Sum256` and `Sum224`, and optimizes the code so that calling them does not allocate any memory on the heap. The standard `New+Write+Sum` API allocations are also reduced:

```
$ go test -benchmem -bench .
goos: linux
goarch: amd64
pkg: github.com/teknico/blake256
Benchmark1K-8          300000   3821 ns/op  267.99 MB/s  144 B/op  1 allocs/op
Benchmark8K-8           50000  28272 ns/op  289.75 MB/s  144 B/op  1 allocs/op
Benchmark64-8         3000000    550 ns/op  116.30 MB/s  144 B/op  1 allocs/op
Benchmark1KNoAlloc-8   300000   3737 ns/op  273.98 MB/s    0 B/op  0 allocs/op
Benchmark8KNoAlloc-8    50000  28334 ns/op  289.11 MB/s    0 B/op  0 allocs/op
Benchmark64NoAlloc-8  3000000    506 ns/op  126.40 MB/s    0 B/op  0 allocs/op
```

New tests and benchmarks are also added, and the tests package is made different from the code one. The tests do not need access to code internals anyway, blackbox testing for the win!